### PR TITLE
Fix per fail di `set -o pipefail` su distro linux con sh!=bash (ad es……. Ubuntu)

### DIFF
--- a/satosa/pki/build_spid_certs.sh
+++ b/satosa/pki/build_spid_certs.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -euo pipefail
 COMMON_NAME=satosa


### PR DESCRIPTION
Fix per fail di `set -o pipefail` su distro linux con sh!=bash (ad es……. Ubuntu)